### PR TITLE
DSE-28613: Update CML AMP Video Classification to latest Runtime version

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -10,7 +10,6 @@ runtimes:
   - editor: Workbench
     kernel: Python 3.9
     edition: Standard
-    version: 2021.12
 
 tasks:
   - type: run_session


### PR DESCRIPTION
This PR removes version field form .project-metadata.yaml so that AMP could use latest Runtime version